### PR TITLE
Set spreading factor in uplink to real value from stats

### DIFF
--- a/examples/lorawan-nano-gateway/nanogateway.py
+++ b/examples/lorawan-nano-gateway/nanogateway.py
@@ -129,7 +129,7 @@ class NanoGateway:
         return int(sf)
 
     def _sf_to_dr(self, sf):
-        return "SF7BW125"
+        return "SF%dBW125" % sf
 
     def _make_stat_packet(self):
         now = self.rtc.now()


### PR DESCRIPTION
Returning the hard coded value works if that is the spreading factor the nano gateway uses, however if the gateway is configured to use a different spreading factor the back-end processing an uplink packet will receive conflicting meta data if another (full) LoRaWAN gateway happens to forward the packet as well. This results in the data from one of the two sources being dropped in the back-end. When meta data for a packet matches from multiple gateways the back-end can consolidate the data and provide the application with the correct meta data of the packet and meta data of all the gateways forwarding the packet (at least for TTN)