### PR TITLE
Add declarations for ALTITUDE and PRESSURE constants to main.py example

### DIFF
--- a/pysense/main.py
+++ b/pysense/main.py
@@ -6,6 +6,9 @@ from SI7006A20 import SI7006A20
 from LTR329ALS01 import LTR329ALS01
 from MPL3115A2 import MPL3115A2
 
+ALTITUDE = const(0)
+PRESSURE = const(1)
+
 py = Pysense()
 mp = MPL3115A2(py,mode=ALTITUDE) # Returns height in meters. Mode may also be set to PRESSURE, returning a value in Pascals
 si = SI7006A20(py)


### PR DESCRIPTION
Added definition for ```ALTITUDE``` and ```PRESSURE``` constants so that they can be used in the demo. Currently ```ALTITUDE``` is used in ```main.py``` but it is not defined in the file so the example doesn't work.