### PR TITLE
Fix issue #28 pytrack coordinates() returns unexpected (None, None)

### DIFF
--- a/pytrack/lib/L76GNSS.py
+++ b/pytrack/lib/L76GNSS.py
@@ -40,6 +40,7 @@ class L76GNSS:
     def coordinates(self, debug=False):
         lat_d, lon_d, debug_timeout = None, None, False
         if self.timeout != None:
+            self.chrono.reset()
             self.chrono.start()
         nmea = b''
         while True:


### PR DESCRIPTION
Properly reset chrono in coordinates().