### PR TITLE
function name start_convertion() should be start_conversion()

### DIFF
--- a/examples/DS18X20/main.py
+++ b/examples/DS18X20/main.py
@@ -8,7 +8,7 @@ ow = OneWire(Pin('P10'))
 temp = DS18X20(ow)
 
 while True:
-    temp.start_convertion()    
+    temp.start_conversion()
     time.sleep(1)
     print(temp.read_temp_async())
     time.sleep(1)

--- a/examples/DS18X20/onewire.py
+++ b/examples/DS18X20/onewire.py
@@ -173,7 +173,7 @@ class DS18X20(object):
         """
         return not self.ow.read_bit()
 
-    def start_convertion(self, rom=None):
+    def start_conversion(self, rom=None):
         """
         Start the temp conversion on one DS18x20 device.
         Pass the 8-byte bytes object with the ROM of the specific device you want to read.


### PR DESCRIPTION
I fixed the function name start_convertion() to start_conversion(), because the spellign was wrong.