### PR TITLE
Fixed accelerometer functions

### DIFF
--- a/pysense/lib/LIS2HH12.py
+++ b/pysense/lib/LIS2HH12.py
@@ -86,26 +86,14 @@ class LIS2HH12:
         return (self.x[0] * _mult, self.y[0] * _mult, self.z[0] * _mult)
 
     def roll(self):
-        self.acceleration()
-        div = math.sqrt(math.pow(self.y[0], 2) + math.pow(self.z[0], 2))
-        if div == 0:
-            div = 0.01
-        return (180 / 3.14154) * math.atan(self.x[0] / div)
+        x,y,z = self.acceleration()
+        rad = math.atan2(-x, z)
+        return (180 / math.pi) * rad
 
     def pitch(self):
-        self.acceleration()
-        if self.z[0] == 0:
-            div = 1
-        else:
-            div = self.z[0]
-        return (180 / 3.14154) * math.atan(math.sqrt(math.pow(self.x[0], 2) + math.pow(self.y[0], 2)) / div)
-
-    def yaw(self):
-        self.acceleration()
-        div = math.sqrt(math.pow(self.x[0], 2) + math.pow(self.z[0], 2))
-        if div == 0:
-            div = 0.01
-        return (180 / 3.14154) * math.atan(self.y[0] / div)
+        x,y,z = self.acceleration()
+        rad = -math.atan2(y, (math.sqrt(x*x + z*z)))
+        return (180 / math.pi) * rad
 
     def set_full_scale(self, scale):
         self.i2c.readfrom_mem_into(ACC_I2CADDR , CTRL4_REG, self.reg)

--- a/pytrack/lib/LIS2HH12.py
+++ b/pytrack/lib/LIS2HH12.py
@@ -86,26 +86,14 @@ class LIS2HH12:
         return (self.x[0] * _mult, self.y[0] * _mult, self.z[0] * _mult)
 
     def roll(self):
-        self.acceleration()
-        div = math.sqrt(math.pow(self.y[0], 2) + math.pow(self.z[0], 2))
-        if div == 0:
-            div = 0.01
-        return (180 / 3.14154) * math.atan(self.x[0] / div)
+        x,y,z = self.acceleration()
+        rad = math.atan2(-x, z)
+        return (180 / math.pi) * rad
 
     def pitch(self):
-        self.acceleration()
-        if self.z[0] == 0:
-            div = 1
-        else:
-            div = self.z[0]
-        return (180 / 3.14154) * math.atan(math.sqrt(math.pow(self.x[0], 2) + math.pow(self.y[0], 2)) / div)
-
-    def yaw(self):
-        self.acceleration()
-        div = math.sqrt(math.pow(self.x[0], 2) + math.pow(self.z[0], 2))
-        if div == 0:
-            div = 0.01
-        return (180 / 3.14154) * math.atan(self.y[0] / div)
+        x,y,z = self.acceleration()
+        rad = -math.atan2(y, (math.sqrt(x*x + z*z)))
+        return (180 / math.pi) * rad
 
     def set_full_scale(self, scale):
         self.i2c.readfrom_mem_into(ACC_I2CADDR , CTRL4_REG, self.reg)


### PR DESCRIPTION
The accelerometer pitch and roll functions now return sensible values:
 - Roll: Returns -180 to 180 degrees
 - Pitch: Returns -90 to 90 degrees which repeats when the board is upside down
          due to a lack of yaw measurement. (-90 > 0 > 90 > -90 )

Removed yaw function because it is not possible to measure yaw using just an accelerometer.