### PR TITLE
Remove sleep_us(1) in read_bit and write_bit

### DIFF
--- a/lib/onewire/onewire.py
+++ b/lib/onewire/onewire.py
@@ -45,9 +45,7 @@ class OneWire:
         pin(1) # half of the devices don't match CRC without this line
         i = machine.disable_irq()
         pin(0)
-        sleep_us(1)
         pin(1)
-        sleep_us(1)
         value = pin()
         enable_irq(i)
         sleep_us(40)
@@ -71,7 +69,6 @@ class OneWire:
 
         i = machine.disable_irq()
         pin(0)
-        sleep_us(1)
         pin(value)
         sleep_us(60)
         pin(1)


### PR DESCRIPTION
The 1 us sleep command does not work on pycom devices. It generates a wait time up to 30us. Without waiting time you get an impulse from at least 10us. Removing the waiting time improves significantly the stability of the communication of the new pycom devices as LoPy4, FiPy etc.
See whole case at https://forum.pycom.io/topic/2570/onewire-ds18x20-reading-not-stable-with-lopy4-no-problem-with-lopy/
Remark: There would be an additional improvement by adding gc.collect() to read_byte and write_byte, but to keep the lib as basic as possible I propose not to integrate it into the lib