### PR TITLE
Fixed endian for .to_bytes() - mqtt.py

### DIFF
--- a/examples/mqtt/mqtt.py
+++ b/examples/mqtt/mqtt.py
@@ -136,7 +136,7 @@ class MQTTClient:
         #print(hex(len(pkt)), hexlify(pkt, ":"))
         self.sock.write(pkt)
         self._send_str(topic)
-        self.sock.write(qos.to_bytes(1))
+        self.sock.write(qos.to_bytes(1, "little"))
         while 1:
             op = self.wait_msg()
             if op == 0x90:


### PR DESCRIPTION
Fixed endian for .to_bytes() - Throws a 'missing argument' error without the endian specified.