### PR TITLE
nanogateway.py: use ticks_add() and ticks_diff() instead + and -

### DIFF
--- a/examples/lorawan-nano-gateway/nanogateway.py
+++ b/examples/lorawan-nano-gateway/nanogateway.py
@@ -8,6 +8,7 @@ import uos
 import usocket
 import utime
 import _thread
+import gc
 from micropython import const
 from network import LoRa
 from network import WLAN
@@ -357,6 +358,7 @@ class NanoGateway:
         """
 
         while not self.udp_stop:
+            gc.collect()
             try:
                 data, src = self.sock.recvfrom(1024)
                 _token = data[1:3]
@@ -369,8 +371,8 @@ class NanoGateway:
                     self.dwnb += 1
                     ack_error = TX_ERR_NONE
                     tx_pk = ujson.loads(data[4:])
-                    tmst = utime.ticks_add(tx_pk["txpk"]["tmst"], - 8000) # pull 8 ms upfront
-                    t_us = utime.ticks_diff(utime.ticks_us(), utime.ticks_add(tmst, - 15000))
+                    tmst = utime.ticks_add(tx_pk["txpk"]["tmst"], -4000) # pull 4 ms upfront
+                    t_us = utime.ticks_diff(utime.ticks_us(), utime.ticks_add(tmst, -15000))
                     if 1000 < t_us < 10000000:
                         self.uplink_alarm = Timer.Alarm(
                             handler=lambda x: self._send_down_link(


### PR DESCRIPTION
The time stamps returned by ticks_ms() overflow after a while.
Therefore they should not simply be added or subtracted.
ticks_add(9 and ticks_diff() are to be used instead.

Also: pull upfront the downlink send time by 8 ms to cope with internal
delays. Then there is a better match with the receive window1.