### PR TITLE
onewire.py: Optimize timing, enable CRC check and slim the code

### DIFF
--- a/examples/DS18X20/onewire.py
+++ b/examples/DS18X20/onewire.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
-
+#
+# The crc8 implementation is a Python port of the C code published here:
+# http://lentz.com.au/blog/tag/crc-table-generator
+# As far as suitable, the copyrigth notice and the disclaimer of the link apply
+#
 """
 OneWire library for MicroPython
 """

--- a/examples/DS18X20/onewire.py
+++ b/examples/DS18X20/onewire.py
@@ -108,8 +108,8 @@ class OneWire:
         Compute CRC, based on tables
         """
         crc = 0
-        for i in range(len(data)):
-           crc ^= data[i] ## just re-using crc as intermediate
+        for byte in data:
+           crc ^= byte ## just re-using crc as intermediate
            crc = (self.crctab1[crc & 0x0f] ^
                   self.crctab2[(crc >> 4) & 0x0f])
         return crc

--- a/examples/DS18X20/onewire.py
+++ b/examples/DS18X20/onewire.py
@@ -207,8 +207,7 @@ class DS18X20(object):
             ow.select_rom(rom)
             ow.write_byte(0xbe)  # Read scratch
             data = ow.read_bytes(9)
-            crc = ow.crc8(data)
-            if crc == 0:
+            if ow.crc8(data) == 0:
                 return self.convert_temp(rom[0], data)
             else:
                 return None

--- a/examples/lorawan-nano-gateway/nanogateway.py
+++ b/examples/lorawan-nano-gateway/nanogateway.py
@@ -390,7 +390,7 @@ class NanoGateway:
             except usocket.timeout:
                 pass
             except OSError as ex:
-                if ex.errno != errno.EAGAIN:
+                if ex.args[0] != errno.EAGAIN:
                     self._log('UDP recv OSError Exception: {}', ex)
             except Exception as ex:
                 self._log('UDP recv Exception: {}', ex)


### PR DESCRIPTION
The reason for a change was the observation, that with about 1 in
300 measurements were wrong, some of them obviously. So I made a few
changes:

1. The timing of readbit was changed to shorten the initial low puls
to 2 µs by not calling sleep_us() at all and reading the state of the bit
about 8 µs later. That matches better the datasheet.
2. The CRC check was enabled in the method read_temp_async(). The function
returns None, when the CRC is wrong
3. The crc8() method is now table based, with two 16 byte tables, which is
about 5 times faster (1.9 ms -> 0.37 ms for 9 bytes)
4. Some inefficient optimizations in the onwire class were removed.
Especially caching system call names in local variables for calls
used only once in a functions was dropped and replaced by storing
the callee names in the class. That saves a few microseconds - maybe not worth
the effort.

With change 1, readings with wrong crc are more rare now, about 1 in 15000, 
and enabling the crc check allows to detect them.

The crc8 implementation is a Python port of the code published here:
http://lentz.com.au/blog/tag/crc-table-generator