### PR TITLE
Pysense improved sleep current

### DIFF
--- a/lib/pycoproc/pycoproc.py
+++ b/lib/pycoproc/pycoproc.py
@@ -32,6 +32,8 @@ class Pycoproc:
     PYTRACK = const(2)
     PYSCAN = const(3)
 
+    BOARD_TYPE_SET = (PYSENSE, PYTRACK, PYSCAN)
+
     CMD_PEEK = const(0x0)
     CMD_POKE = const(0x01)
     CMD_MAGIC = const(0x02)
@@ -87,11 +89,14 @@ class Pycoproc:
 
     EXP_RTC_PERIOD = const(7000)
 
-    def __init__(self, i2c=None, sda='P22', scl='P21', board_type = PYTRACK):
+    def __init__(self, board_type, i2c=None, sda='P22', scl='P21'):
         if i2c is not None:
             self.i2c = i2c
         else:
             self.i2c = I2C(0, mode=I2C.MASTER, pins=(sda, scl))
+
+        if board_type not in self.BOARD_TYPE_SET:
+            raise Exception('Board type not in the set {}'.format(self.BOARD_TYPE_SET))
 
         self.sda = sda
         self.scl = scl

--- a/lib/pycoproc/pycoproc.py
+++ b/lib/pycoproc/pycoproc.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python
 #
-# Copyright (c) 2019, Pycom Limited.
+# Copyright (c) 2020, Pycom Limited.
 #
 # This software is licensed under the GNU GPL version 3 or any
 # later version, with permitted additional terms. For more information
 # see the Pycom Licence v1.0 document supplied with this file, or
 # available at https://www.pycom.io/opensource/licensing
 #
+
+# See https://docs.pycom.io for more information regarding library specifics
 
 from machine import Pin
 from machine import I2C
@@ -25,6 +27,10 @@ class Pycoproc:
     """ class for handling the interaction with PIC MCU """
 
     I2C_SLAVE_ADDR = const(8)
+
+    PYSENSE = const(1)
+    PYTRACK = const(2)
+    PYSCAN = const(3)
 
     CMD_PEEK = const(0x0)
     CMD_POKE = const(0x01)
@@ -81,14 +87,15 @@ class Pycoproc:
 
     EXP_RTC_PERIOD = const(7000)
 
-    def __init__(self, i2c=None, sda='P22', scl='P21'):
+    def __init__(self, i2c=None, sda='P22', scl='P21', board_type = PYTRACK):
         if i2c is not None:
             self.i2c = i2c
         else:
-            self.i2c = I2C(0, mode=I2C.MASTER, pins=(sda, scl), baudrate=100000)
+            self.i2c = I2C(0, mode=I2C.MASTER, pins=(sda, scl))
 
         self.sda = sda
         self.scl = scl
+        self.board_type = board_type
         self.clk_cal_factor = 1
         self.reg = bytearray(6)
         self.wake_int = False
@@ -202,11 +209,14 @@ class Pycoproc:
         self._write(bytes([CMD_SETUP_SLEEP, time_s & 0xFF, (time_s >> 8) & 0xFF, (time_s >> 16) & 0xFF]))
 
     def go_to_sleep(self, gps=True):
-        # enable or disable back-up power to the GPS receiver
-        if gps:
+        # if we have a Pytrack then enable or disable back-up power to the GPS receiver
+        if self.board_type == self.PYTRACK and gps:
+            # disable GPS only if Pytrack
             self.set_bits_in_memory(PORTC_ADDR, 1 << 7)
         else:
+            # Pysense or Pyscan or no GPS
             self.mask_bits_in_memory(PORTC_ADDR, ~(1 << 7))
+
         # disable the ADC
         self.poke_memory(ADCON0_ADDR, 0)
 
@@ -245,7 +255,7 @@ class Pycoproc:
         self.i2c.deinit()
         Pin('P21', mode=Pin.IN)
         pulses = pycom.pulses_get('P21', 100)
-        self.i2c.init(mode=I2C.MASTER, pins=(self.sda, self.scl), baudrate=100000)
+        self.i2c.init(mode=I2C.MASTER, pins=(self.sda, self.scl))
         idx = 0
         for i in range(len(pulses)):
             if pulses[i][1] > EXP_RTC_PERIOD:

--- a/pyscan/lib/pyscan.py
+++ b/pyscan/lib/pyscan.py
@@ -1,8 +1,8 @@
 from pycoproc import Pycoproc
 
-__version__ = '1.0.0'
+__version__ = '1.0.1'
 
 class Pyscan(Pycoproc):
 
     def __init__(self, i2c=None, sda='P22', scl='P21'):
-        Pycoproc.__init__(self, i2c, sda, scl)
+        Pycoproc.__init__(self, Pycoproc.PYSCAN, i2c, sda, scl)

--- a/pyscan/lib/pyscan.py
+++ b/pyscan/lib/pyscan.py
@@ -1,3 +1,13 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2020, Pycom Limited.
+#
+# This software is licensed under the GNU GPL version 3 or any
+# later version, with permitted additional terms. For more information
+# see the Pycom Licence v1.0 document supplied with this file, or
+# available at https://www.pycom.io/opensource/licensing
+#
+
 from pycoproc import Pycoproc
 
 __version__ = '1.0.1'

--- a/pysense/lib/LIS2HH12.py
+++ b/pysense/lib/LIS2HH12.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (c) 2019, Pycom Limited.
+# Copyright (c) 2020, Pycom Limited.
 #
 # This software is licensed under the GNU GPL version 3 or any
 # later version, with permitted additional terms. For more information

--- a/pysense/lib/LTR329ALS01.py
+++ b/pysense/lib/LTR329ALS01.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (c) 2019, Pycom Limited.
+# Copyright (c) 2020, Pycom Limited.
 #
 # This software is licensed under the GNU GPL version 3 or any
 # later version, with permitted additional terms. For more information

--- a/pysense/lib/MPL3115A2.py
+++ b/pysense/lib/MPL3115A2.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (c) 2019, Pycom Limited.
+# Copyright (c) 2020, Pycom Limited.
 #
 # This software is licensed under the GNU GPL version 3 or any
 # later version, with permitted additional terms. For more information

--- a/pysense/lib/pysense.py
+++ b/pysense/lib/pysense.py
@@ -17,4 +17,4 @@ __version__ = '1.4.1'
 class Pysense(Pycoproc):
 
     def __init__(self, i2c=None, sda='P22', scl='P21'):
-        Pycoproc.__init__(self, i2c, sda, scl, Pycoproc.PYSENSE)
+        Pycoproc.__init__(self, Pycoproc.PYSENSE, i2c, sda, scl)

--- a/pysense/lib/pysense.py
+++ b/pysense/lib/pysense.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (c) 2019, Pycom Limited.
+# Copyright (c) 2020, Pycom Limited.
 #
 # This software is licensed under the GNU GPL version 3 or any
 # later version, with permitted additional terms. For more information
@@ -8,11 +8,13 @@
 # available at https://www.pycom.io/opensource/licensing
 #
 
+# See https://docs.pycom.io for more information regarding library specifics
+
 from pycoproc import Pycoproc
 
-__version__ = '1.4.0'
+__version__ = '1.4.1'
 
 class Pysense(Pycoproc):
 
     def __init__(self, i2c=None, sda='P22', scl='P21'):
-        Pycoproc.__init__(self, i2c, sda, scl)
+        Pycoproc.__init__(self, i2c, sda, scl, Pycoproc.PYSENSE)

--- a/pysense/main.py
+++ b/pysense/main.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (c) 2019, Pycom Limited.
+# Copyright (c) 2020, Pycom Limited.
 #
 # This software is licensed under the GNU GPL version 3 or any
 # later version, with permitted additional terms. For more information
@@ -10,32 +10,50 @@
 
 # See https://docs.pycom.io for more information regarding library specifics
 
+import time
+import pycom
+from pysense import Pysense
+import machine
+
 from pysense import Pysense
 from LIS2HH12 import LIS2HH12
 from SI7006A20 import SI7006A20
 from LTR329ALS01 import LTR329ALS01
 from MPL3115A2 import MPL3115A2,ALTITUDE,PRESSURE
 
-py = Pysense()
-mp = MPL3115A2(py,mode=ALTITUDE) # Returns height in meters. Mode may also be set to PRESSURE, returning a value in Pascals
-si = SI7006A20(py)
-lt = LTR329ALS01(py)
-li = LIS2HH12(py)
+pycom.heartbeat(False)
+pycom.rgbled(0x0A0A08) # white
 
+py = Pysense()
+
+mp = MPL3115A2(py,mode=ALTITUDE) # Returns height in meters. Mode may also be set to PRESSURE, returning a value in Pascals
 print("MPL3115A2 temperature: " + str(mp.temperature()))
 print("Altitude: " + str(mp.altitude()))
 mpp = MPL3115A2(py,mode=PRESSURE) # Returns pressure in Pa. Mode may also be set to ALTITUDE, returning a value in meters
 print("Pressure: " + str(mpp.pressure()))
 
+
+si = SI7006A20(py)
 print("Temperature: " + str(si.temperature())+ " deg C and Relative Humidity: " + str(si.humidity()) + " %RH")
 print("Dew point: "+ str(si.dew_point()) + " deg C")
 t_ambient = 24.4
 print("Humidity Ambient for " + str(t_ambient) + " deg C is " + str(si.humid_ambient(t_ambient)) + "%RH")
 
+
+lt = LTR329ALS01(py)
 print("Light (channel Blue lux, channel Red lux): " + str(lt.light()))
 
+li = LIS2HH12(py)
 print("Acceleration: " + str(li.acceleration()))
 print("Roll: " + str(li.roll()))
 print("Pitch: " + str(li.pitch()))
 
 print("Battery voltage: " + str(py.read_battery_voltage()))
+
+time.sleep(3)
+py.setup_sleep(10)
+py.go_to_sleep()
+
+# except:
+#     import machine
+#     machine.reset()

--- a/pysense/main.py
+++ b/pysense/main.py
@@ -15,7 +15,6 @@ import pycom
 from pysense import Pysense
 import machine
 
-from pysense import Pysense
 from LIS2HH12 import LIS2HH12
 from SI7006A20 import SI7006A20
 from LTR329ALS01 import LTR329ALS01
@@ -53,7 +52,3 @@ print("Battery voltage: " + str(py.read_battery_voltage()))
 time.sleep(3)
 py.setup_sleep(10)
 py.go_to_sleep()
-
-# except:
-#     import machine
-#     machine.reset()

--- a/pytrack/lib/LIS2HH12.py
+++ b/pytrack/lib/LIS2HH12.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (c) 2019, Pycom Limited.
+# Copyright (c) 2020, Pycom Limited.
 #
 # This software is licensed under the GNU GPL version 3 or any
 # later version, with permitted additional terms. For more information

--- a/pytrack/lib/pytrack.py
+++ b/pytrack/lib/pytrack.py
@@ -15,4 +15,4 @@ __version__ = '1.4.1'
 class Pytrack(Pycoproc):
 
     def __init__(self, i2c=None, sda='P22', scl='P21'):
-        Pycoproc.__init__(self, i2c, sda, scl, Pycoproc.PYTRACK)
+        Pycoproc.__init__(self, Pycoproc.PYTRACK, i2c, sda, scl)

--- a/pytrack/lib/pytrack.py
+++ b/pytrack/lib/pytrack.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (c) 2019, Pycom Limited.
+# Copyright (c) 2020, Pycom Limited.
 #
 # This software is licensed under the GNU GPL version 3 or any
 # later version, with permitted additional terms. For more information
@@ -10,9 +10,9 @@
 
 from pycoproc import Pycoproc
 
-__version__ = '1.4.0'
+__version__ = '1.4.1'
 
 class Pytrack(Pycoproc):
 
     def __init__(self, i2c=None, sda='P22', scl='P21'):
-        Pycoproc.__init__(self, i2c, sda, scl)
+        Pycoproc.__init__(self, i2c, sda, scl, Pycoproc.PYTRACK)

--- a/pytrack/main.py
+++ b/pytrack/main.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (c) 2019, Pycom Limited.
+# Copyright (c) 2020, Pycom Limited.
 #
 # This software is licensed under the GNU GPL version 3 or any
 # later version, with permitted additional terms. For more information


### PR DESCRIPTION
pycoproc added constructor parameter

## What does this implement/fix? Explain your changes.
On Pysense the pysense.go_to_sleep() method did not turned off pressure sensor power. So power consumption was 289uA (@3.7V). Now the current consumption in sleep dropped to 9uA.

## Does this close any currently open issues?
Issue was raised by customer.

## Any relevant logs, error output, etc?
*(If it’s long, please paste to https://gist.github.com and insert the link here)*


## Any other comments?


## Where has this been tested?
- **Pysense v1.1, Fipy v1.2**
- **(sysname='FiPy', nodename='FiPy', release='1.20.2.rc3', version='v1.11-2037465 on 2020-02-05', machine='FiPy with ESP32', lorawan='1.0.2', sigfox='1.0.1', pybytes='1.3.1')**
