### PR TITLE
Ensure checksum is 2 digits

### DIFF
--- a/shields/lib/L76GNSS.py
+++ b/shields/lib/L76GNSS.py
@@ -113,7 +113,7 @@ class L76GNSS:
         calc_cksum = 0
         for s in nmeadata:
             calc_cksum ^= ord(s)
-        return('{:X}'.format(calc_cksum))
+        return('{:02X}'.format(calc_cksum))
 
     def write(self, data):
         self.i2c.writeto(GPS_I2CADDR, '${}*{}\r\n'.format(data, self._checksum(data)) )


### PR DESCRIPTION
Fix bug where some L76 messages are ignored due to the checksum being one digit long (i.e. 'F') vs. the expected 2 digit length ('0F')

(Hi! 👋 Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)

## What does this implement/fix? Explain your changes.
Sometimes, messages written to the L76 are ignored due to an invalid checksum

## Does this close any currently open issues?
None afaik

## Any relevant logs, error output, etc?
*(If it’s long, please paste to https://gist.github.com and insert the link here)*
`l76.write("PMTK740,{},{},{},{},{},{}".format(curtime[0], curtime[1], curtime[2], curtime[3], curtime[4], curtime[5]))` used to result in
`$PMTK740,2021,4,8,19,0,57*6` being sent, which was missing the second checksum digit, causing the message to be ignored

## Any other comments?


## Where has this been tested?
- **Board type and hardware version:**
Pytrack 2.0X, GPY 1.0
- **`os.uname()` output:**
(sysname='GPy', nodename='GPy', release='1.20.2.r4', version='v1.11-ffb0e1c on 2021-01-12', machine='GPy with ESP32', pybytes='1.6.1')