### PR TITLE
Update MFRC630.py

### DIFF
--- a/shields/lib/MFRC630.py
+++ b/shields/lib/MFRC630.py
@@ -370,7 +370,7 @@ class MFRC630:
         buffer_length = self.mfrc630_fifo_length()
         rx_len = buffer_length if (buffer_length <= 16) else 16
         dest = self.mfrc630_read_fifo(rx_len)
-        return rx_len
+        return dest
 
 
     def mfrc630_iso14443a_WUPA_REQA(self, instruction):


### PR DESCRIPTION
Fix for https://forum.pycom.io/topic/6981/pyscan-nfc-rfid-reading-issue/

Decoding a NFC card would previously return all 0's because of this bug. Instead of returning the data, we would return the length, which would make the following function calls print all 0's instead of the decoded data.

I was not able to test this personally because of a lack of decodable keycards
