### PR TITLE
Add region to config in order for nano gateway to start up

### DIFF
--- a/examples/lorawan-nano-gateway/config.py
+++ b/examples/lorawan-nano-gateway/config.py
@@ -12,6 +12,7 @@
 
 import machine
 import ubinascii
+from network import LoRa
 
 WIFI_MAC = ubinascii.hexlify(machine.unique_id()).upper()
 # Set  the Gateway ID to be the first 3 bytes of MAC address + 'FFFE' + last 3 bytes of MAC address
@@ -27,6 +28,7 @@ WIFI_SSID = 'my-wifi'
 WIFI_PASS = 'my-wifi-password'
 
 # for EU868
+LORA_REGION = LoRa.EU868
 LORA_FREQUENCY = 868100000
 LORA_GW_DR = "SF7BW125" # DR_5
 LORA_NODE_DR = 5

--- a/examples/lorawan-nano-gateway/main.py
+++ b/examples/lorawan-nano-gateway/main.py
@@ -24,7 +24,7 @@ if __name__ == '__main__':
         port=config.PORT,
         ntp_server=config.NTP,
         ntp_period=config.NTP_PERIOD_S,
-        regoin=config.LORA_REGION
+        region=config.LORA_REGION
         )
 
     nanogw.start()

--- a/examples/lorawan-nano-gateway/main.py
+++ b/examples/lorawan-nano-gateway/main.py
@@ -23,7 +23,8 @@ if __name__ == '__main__':
         server=config.SERVER,
         port=config.PORT,
         ntp_server=config.NTP,
-        ntp_period=config.NTP_PERIOD_S
+        ntp_period=config.NTP_PERIOD_S,
+        regoin=config.LORA_REGION
         )
 
     nanogw.start()

--- a/examples/lorawan-nano-gateway/nanogateway.py
+++ b/examples/lorawan-nano-gateway/nanogateway.py
@@ -91,7 +91,7 @@ class NanoGateway:
     connecting to the Internet.
     """
 
-    def __init__(self, id, frequency, datarate, ssid, password, server, port, ntp_server='pool.ntp.org', ntp_period=3600):
+    def __init__(self, id, frequency, datarate, ssid, password, server, port, ntp_server='pool.ntp.org', ntp_period=3600, region=LoRa.EU868):
         self.id = id
         self.server = server
         self.port = port
@@ -175,7 +175,8 @@ class NanoGateway:
             sf=self.sf,
             preamble=8,
             coding_rate=LoRa.CODING_4_5,
-            tx_iq=True
+            tx_iq=True,
+            region=self.region
         )
 
         # create a raw LoRa socket
@@ -268,7 +269,8 @@ class NanoGateway:
                 sf=self.sf,
                 preamble=8,
                 coding_rate=LoRa.CODING_4_5,
-                tx_iq=True
+                tx_iq=True,
+                region=self.region
                 )
 
     def _freq_to_float(self, frequency):
@@ -359,7 +361,8 @@ class NanoGateway:
             sf=self._dr_to_sf(datarate),
             preamble=8,
             coding_rate=LoRa.CODING_4_5,
-            tx_iq=True
+            tx_iq=True,
+            region=self.region
             )
         #while utime.ticks_cpu() < tmst:
         #    pass
@@ -381,7 +384,8 @@ class NanoGateway:
             preamble=8,
             coding_rate=LoRa.CODING_4_5,
             tx_iq=True,
-            device_class=LoRa.CLASS_C
+            device_class=LoRa.CLASS_C,
+            region=self.region
             )
 
         self.lora_sock.send(data)

--- a/examples/lorawan-nano-gateway/nanogateway.py
+++ b/examples/lorawan-nano-gateway/nanogateway.py
@@ -129,6 +129,7 @@ class NanoGateway:
         self.lora_sock = None
 
         self.rtc = machine.RTC()
+        self.region = region
 
     def start(self):
         """


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
The example LoRa nano gateway doesn't start up because the region flag is not passed on LoRa class creation/init

## Does this close any currently open issues?


## Any relevant logs, error output, etc?
No


## Any other comments?


## Where has this been tested?
LoPy4, macOS big sure