### PR TITLE
pymesh: do not (re-)create LoRa instances in pymesh_config

### DIFF
--- a/pymesh/pymesh_frozen/lib/pymesh_config.py
+++ b/pymesh/pymesh_frozen/lib/pymesh_config.py
@@ -5,7 +5,6 @@ later version, with permitted additional terms. For more information
 see the Pycom Licence v1.0 document supplied with this file, or
 available at https://www.pycom.io/opensource/licensing
 '''
-import ubinascii
 import json
 
 from network import LoRa
@@ -78,10 +77,7 @@ class PymeshConfig:
             time.sleep(1)
             machine.deepsleep(1000)
 
-    def check_mac(pymesh_config):
-        lora = LoRa(mode=LoRa.LORA, region= LoRa.EU868)
-        MAC = int(str(ubinascii.hexlify(lora.mac()))[2:-1], 16)
-
+    def check_mac(pymesh_config, MAC):
         if pymesh_config.get('MAC') is None:
             # if MAC config unspecified, set it to LoRa MAC
             print_debug(3, "Set MAC in config file as " + str(MAC))
@@ -102,7 +98,7 @@ class PymeshConfig:
 
         print_debug(3, "MAC ok" + str(MAC))
 
-    def read_config():
+    def read_config(MAC):
         file = PymeshConfig.CONFIG_FILENAME
         pymesh_config = {}
         error_file = True
@@ -138,10 +134,10 @@ class PymeshConfig:
             pymesh_config['br_ena'] = PymeshConfig.BR_ENABLE
             pymesh_config['br_prio'] = PymeshConfig.BR_PRIORITY
 
-            PymeshConfig.check_mac(pymesh_config)
+            PymeshConfig.check_mac(pymesh_config, MAC)
             print_debug(3, "Default settings:" + str(pymesh_config))
             PymeshConfig.write_config(pymesh_config, True)
 
-        PymeshConfig.check_mac(pymesh_config)
+        PymeshConfig.check_mac(pymesh_config, MAC)
         print_debug(3, "Settings:" + str(pymesh_config))
         return pymesh_config

--- a/pymesh/pymesh_frozen/lorawan/main.py
+++ b/pymesh/pymesh_frozen/lorawan/main.py
@@ -1,5 +1,7 @@
-import pycom
 import time
+import ubinascii
+import pycom
+from network import LoRa
 
 try:
     from pymesh_config import PymeshConfig
@@ -28,8 +30,11 @@ def new_message_cb(rcv_ip, rcv_port, rcv_data):
 
 pycom.heartbeat(False)
 
+lora = LoRa(mode=LoRa.LORA, region= LoRa.EU868)
+lora_mac = int(str(ubinascii.hexlify(lora.mac()))[2:-1], 16)
+
 # read config file, or set default values
-pymesh_config = PymeshConfig.read_config()
+pymesh_config = PymeshConfig.read_config(lora_mac)
 
 #initialize Pymesh
 pymesh = Pymesh(pymesh_config, new_message_cb)

--- a/pymesh/pymesh_frozen/main.py
+++ b/pymesh/pymesh_frozen/main.py
@@ -1,5 +1,7 @@
-import pycom
 import time
+import ubinascii
+import pycom
+from network import LoRa
 
 try:
     from pymesh_config import PymeshConfig
@@ -28,8 +30,11 @@ def new_message_cb(rcv_ip, rcv_port, rcv_data):
 
 pycom.heartbeat(False)
 
+lora = LoRa(mode=LoRa.LORA, region= LoRa.EU868)
+lora_mac = int(str(ubinascii.hexlify(lora.mac()))[2:-1], 16)
+
 # read config file, or set default values
-pymesh_config = PymeshConfig.read_config()
+pymesh_config = PymeshConfig.read_config(lora_mac)
 
 #initialize Pymesh
 pymesh = Pymesh(pymesh_config, new_message_cb)

--- a/pymesh/pymesh_frozen/main_BR.py
+++ b/pymesh/pymesh_frozen/main_BR.py
@@ -1,5 +1,7 @@
 import time
+import ubinascii
 import pycom
+from network import LoRa
 
 # 2 = test pybytes OTA feature
 # 4 = added device_id (pybytes token) in the packets to BR
@@ -66,8 +68,11 @@ def new_br_message_cb(rcv_ip, rcv_port, rcv_data, dest_ip, dest_port):
 
 pycom.heartbeat(False)
 
+lora = LoRa(mode=LoRa.LORA, region= LoRa.EU868)
+lora_mac = int(str(ubinascii.hexlify(lora.mac()))[2:-1], 16)
+
 # read config file, or set default values
-pymesh_config = PymeshConfig.read_config()
+pymesh_config = PymeshConfig.read_config(lora_mac)
 
 #initialize Pymesh
 pymesh = Pymesh(pymesh_config, new_message_cb)


### PR DESCRIPTION
It seems there is a rare chance to end up with a frozen device at the point where the lora=LoRa() object is recreated. There is no real need to do this inside pymesh_config, so as a workaround we simply make one object only and pass the lora_mac
